### PR TITLE
fix: register config as command group instead of custom function

### DIFF
--- a/cli/src/fuzzforge_cli/main.py
+++ b/cli/src/fuzzforge_cli/main.py
@@ -117,26 +117,6 @@ def status():
 
 
 @app.command()
-def config(
-    key: Optional[str] = typer.Argument(None, help="Configuration key"),
-    value: Optional[str] = typer.Argument(None, help="Configuration value to set"),
-):
-    """
-    ⚙️  Manage configuration (show all, get, or set values)
-    """
-
-    if key is None:
-        # No arguments: show all config
-        config_cmd.show_config(global_config=False)
-    elif value is None:
-        # Key only: get specific value
-        config_cmd.get_config(key=key, global_config=False)
-    else:
-        # Key and value: set value
-        config_cmd.set_config(key=key, value=value, global_config=False)
-
-
-@app.command()
 def clean(
     days: int = typer.Option(
         90, "--days", "-d", help="Remove data older than this many days"
@@ -366,6 +346,7 @@ app.add_typer(finding_app, name="finding", help="🔍 View and analyze findings"
 # Other command groups
 app.add_typer(ai.app, name="ai", help="🤖 AI integration features")
 app.add_typer(ingest.app, name="ingest", help="🧠 Ingest knowledge into AI")
+app.add_typer(config_cmd.app, name="config", help="⚙️  Manage configuration settings")
 
 
 # Help and utility commands


### PR DESCRIPTION
The config command was implemented as a custom function that manually routed to subcommands, which caused 'ff config show' to fail. It treated 'show' as a configuration key argument instead of a subcommand.

Now properly registered as a Typer command group, enabling all config subcommands (show, set, get, reset, edit) to work correctly.