### PR TITLE
fix: worker naming, monitor commands, and findings CLI improvements

### DIFF
--- a/backend/src/api/runs.py
+++ b/backend/src/api/runs.py
@@ -55,9 +55,12 @@ async def get_run_status(
         is_failed = workflow_status == "FAILED"
         is_running = workflow_status == "RUNNING"
 
+        # Extract workflow name from run_id (format: workflow_name-unique_id)
+        workflow_name = run_id.rsplit('-', 1)[0] if '-' in run_id else "unknown"
+
         return WorkflowStatus(
             run_id=run_id,
-            workflow="unknown",  # Temporal doesn't track workflow name in status
+            workflow=workflow_name,
             status=workflow_status,
             is_completed=is_completed,
             is_failed=is_failed,
@@ -123,6 +126,9 @@ async def get_run_findings(
         else:
             sarif = {}
 
+        # Extract workflow name from run_id (format: workflow_name-unique_id)
+        workflow_name = run_id.rsplit('-', 1)[0] if '-' in run_id else "unknown"
+
         # Metadata
         metadata = {
             "completion_time": status.get("close_time"),
@@ -130,7 +136,7 @@ async def get_run_findings(
         }
 
         return WorkflowFindings(
-            workflow="unknown",
+            workflow=workflow_name,
             run_id=run_id,
             sarif=sarif,
             metadata=metadata

--- a/backend/src/api/workflows.py
+++ b/backend/src/api/workflows.py
@@ -566,7 +566,6 @@ async def get_workflow_worker_info(
     return {
         "workflow": workflow_name,
         "vertical": vertical,
-        "worker_container": f"fuzzforge-worker-{vertical}",
         "worker_service": f"worker-{vertical}",
         "task_queue": f"{vertical}-queue",
         "required": True

--- a/cli/src/fuzzforge_cli/commands/workflow_exec.py
+++ b/cli/src/fuzzforge_cli/commands/workflow_exec.py
@@ -365,7 +365,7 @@ def execute_workflow(
     should_auto_start = auto_start if auto_start is not None else config.workers.auto_start_workers
     should_auto_stop = auto_stop if auto_stop is not None else config.workers.auto_stop_workers
 
-    worker_container = None  # Track for cleanup
+    worker_service = None  # Track for cleanup
     worker_mgr = None
     wait_completed = False  # Track if wait completed successfully
 
@@ -384,7 +384,6 @@ def execute_workflow(
                 )
 
                 # Ensure worker is running
-                worker_container = worker_info["worker_container"]
                 worker_service = worker_info.get("worker_service", f"worker-{worker_info['vertical']}")
                 if not worker_mgr.ensure_worker_running(worker_info, auto_start=should_auto_start):
                     console.print(
@@ -434,7 +433,7 @@ def execute_workflow(
                 # Don't fail the whole operation if database save fails
                 console.print(f"⚠️  Failed to save execution to database: {e}", style="yellow")
 
-            console.print(f"\n💡 Monitor progress: [bold cyan]fuzzforge monitor stats {response.run_id}[/bold cyan]")
+            console.print(f"\n💡 Monitor progress: [bold cyan]fuzzforge monitor live {response.run_id}[/bold cyan]")
             console.print(f"💡 Check status: [bold cyan]fuzzforge workflow status {response.run_id}[/bold cyan]")
 
             # Suggest --live for fuzzing workflows
@@ -461,7 +460,7 @@ def execute_workflow(
                     console.print("\n⏹️  Live monitoring stopped (execution continues in background)", style="yellow")
                 except Exception as e:
                     console.print(f"⚠️  Failed to start live monitoring: {e}", style="yellow")
-                    console.print(f"💡 You can still monitor manually: [bold cyan]fuzzforge monitor {response.run_id}[/bold cyan]")
+                    console.print(f"💡 You can still monitor manually: [bold cyan]fuzzforge monitor live {response.run_id}[/bold cyan]")
 
             # Wait for completion if requested
             elif wait:
@@ -527,11 +526,11 @@ def execute_workflow(
         handle_error(e, "executing workflow")
     finally:
         # Stop worker if auto-stop is enabled and wait completed
-        if should_auto_stop and worker_container and worker_mgr and wait_completed:
+        if should_auto_stop and worker_service and worker_mgr and wait_completed:
             try:
                 console.print("\n🛑 Stopping worker (auto-stop enabled)...")
-                if worker_mgr.stop_worker(worker_container):
-                    console.print(f"✅ Worker stopped: {worker_container}")
+                if worker_mgr.stop_worker(worker_service):
+                    console.print(f"✅ Worker stopped: {worker_service}")
             except Exception as e:
                 console.print(
                     f"⚠️  Failed to stop worker: {e}",
@@ -608,7 +607,7 @@ def workflow_status(
 
         # Show next steps
         if status.is_running:
-            console.print(f"\n💡 Monitor live: [bold cyan]fuzzforge monitor {execution_id}[/bold cyan]")
+            console.print(f"\n💡 Monitor live: [bold cyan]fuzzforge monitor live {execution_id}[/bold cyan]")
         elif status.is_completed:
             console.print(f"💡 View findings: [bold cyan]fuzzforge finding {execution_id}[/bold cyan]")
         elif status.is_failed:
@@ -770,7 +769,7 @@ def retry_workflow(
             except Exception as e:
                 console.print(f"⚠️  Failed to save execution to database: {e}", style="yellow")
 
-            console.print(f"\n💡 Monitor progress: [bold cyan]fuzzforge monitor stats {response.run_id}[/bold cyan]")
+            console.print(f"\n💡 Monitor progress: [bold cyan]fuzzforge monitor live {response.run_id}[/bold cyan]")
 
     except Exception as e:
         handle_error(e, "retrying workflow")

--- a/cli/src/fuzzforge_cli/worker_manager.py
+++ b/cli/src/fuzzforge_cli/worker_manager.py
@@ -95,17 +95,30 @@ class WorkerManager:
             check=True
         )
 
-    def is_worker_running(self, container_name: str) -> bool:
+    def _service_to_container_name(self, service_name: str) -> str:
         """
-        Check if a worker container is running.
+        Convert service name to container name based on docker-compose naming convention.
 
         Args:
-            container_name: Name of the Docker container (e.g., "fuzzforge-worker-ossfuzz")
+            service_name: Docker Compose service name (e.g., "worker-python")
+
+        Returns:
+            Container name (e.g., "fuzzforge-worker-python")
+        """
+        return f"fuzzforge-{service_name}"
+
+    def is_worker_running(self, service_name: str) -> bool:
+        """
+        Check if a worker service is running.
+
+        Args:
+            service_name: Name of the Docker Compose service (e.g., "worker-ossfuzz")
 
         Returns:
             True if container is running, False otherwise
         """
         try:
+            container_name = self._service_to_container_name(service_name)
             result = subprocess.run(
                 ["docker", "inspect", "-f", "{{.State.Running}}", container_name],
                 capture_output=True,
@@ -120,46 +133,42 @@ class WorkerManager:
             logger.debug(f"Failed to check worker status: {e}")
             return False
 
-    def start_worker(self, container_name: str) -> bool:
+    def start_worker(self, service_name: str) -> bool:
         """
-        Start a worker container using docker.
+        Start a worker service using docker-compose.
 
         Args:
-            container_name: Name of the Docker container to start
+            service_name: Name of the Docker Compose service to start (e.g., "worker-python")
 
         Returns:
             True if started successfully, False otherwise
         """
         try:
-            console.print(f"🚀 Starting worker: {container_name}")
+            console.print(f"🚀 Starting worker: {service_name}")
 
-            # Use docker start directly (works with container name)
-            subprocess.run(
-                ["docker", "start", container_name],
-                capture_output=True,
-                text=True,
-                check=True
-            )
+            # Use docker-compose up to create and start the service
+            result = self._run_docker_compose("up", "-d", service_name)
 
-            logger.info(f"Worker {container_name} started")
+            logger.info(f"Worker {service_name} started")
             return True
 
         except subprocess.CalledProcessError as e:
-            logger.error(f"Failed to start worker {container_name}: {e.stderr}")
+            logger.error(f"Failed to start worker {service_name}: {e.stderr}")
             console.print(f"❌ Failed to start worker: {e.stderr}", style="red")
+            console.print(f"💡 Start the worker manually: docker compose up -d {service_name}", style="yellow")
             return False
 
         except Exception as e:
-            logger.error(f"Unexpected error starting worker {container_name}: {e}")
+            logger.error(f"Unexpected error starting worker {service_name}: {e}")
             console.print(f"❌ Unexpected error: {e}", style="red")
             return False
 
-    def wait_for_worker_ready(self, container_name: str, timeout: Optional[int] = None) -> bool:
+    def wait_for_worker_ready(self, service_name: str, timeout: Optional[int] = None) -> bool:
         """
         Wait for a worker to be healthy and ready to process tasks.
 
         Args:
-            container_name: Name of the Docker container
+            service_name: Name of the Docker Compose service
             timeout: Maximum seconds to wait (uses instance default if not specified)
 
         Returns:
@@ -170,13 +179,14 @@ class WorkerManager:
         """
         timeout = timeout or self.startup_timeout
         start_time = time.time()
+        container_name = self._service_to_container_name(service_name)
 
         console.print("⏳ Waiting for worker to be ready...")
 
         while time.time() - start_time < timeout:
             # Check if container is running
-            if not self.is_worker_running(container_name):
-                logger.debug(f"Worker {container_name} not running yet")
+            if not self.is_worker_running(service_name):
+                logger.debug(f"Worker {service_name} not running yet")
                 time.sleep(self.health_check_interval)
                 continue
 
@@ -193,16 +203,16 @@ class WorkerManager:
 
                 # If no health check is defined, assume healthy after running
                 if health_status == "<no value>" or health_status == "":
-                    logger.info(f"Worker {container_name} is running (no health check)")
-                    console.print(f"✅ Worker ready: {container_name}")
+                    logger.info(f"Worker {service_name} is running (no health check)")
+                    console.print(f"✅ Worker ready: {service_name}")
                     return True
 
                 if health_status == "healthy":
-                    logger.info(f"Worker {container_name} is healthy")
-                    console.print(f"✅ Worker ready: {container_name}")
+                    logger.info(f"Worker {service_name} is healthy")
+                    console.print(f"✅ Worker ready: {service_name}")
                     return True
 
-                logger.debug(f"Worker {container_name} health: {health_status}")
+                logger.debug(f"Worker {service_name} health: {health_status}")
 
             except Exception as e:
                 logger.debug(f"Failed to check health: {e}")
@@ -210,41 +220,36 @@ class WorkerManager:
             time.sleep(self.health_check_interval)
 
         elapsed = time.time() - start_time
-        logger.warning(f"Worker {container_name} did not become ready within {elapsed:.1f}s")
+        logger.warning(f"Worker {service_name} did not become ready within {elapsed:.1f}s")
         console.print(f"⚠️  Worker startup timeout after {elapsed:.1f}s", style="yellow")
         return False
 
-    def stop_worker(self, container_name: str) -> bool:
+    def stop_worker(self, service_name: str) -> bool:
         """
-        Stop a worker container using docker.
+        Stop a worker service using docker-compose.
 
         Args:
-            container_name: Name of the Docker container to stop
+            service_name: Name of the Docker Compose service to stop
 
         Returns:
             True if stopped successfully, False otherwise
         """
         try:
-            console.print(f"🛑 Stopping worker: {container_name}")
+            console.print(f"🛑 Stopping worker: {service_name}")
 
-            # Use docker stop directly (works with container name)
-            subprocess.run(
-                ["docker", "stop", container_name],
-                capture_output=True,
-                text=True,
-                check=True
-            )
+            # Use docker-compose down to stop and remove the service
+            result = self._run_docker_compose("stop", service_name)
 
-            logger.info(f"Worker {container_name} stopped")
+            logger.info(f"Worker {service_name} stopped")
             return True
 
         except subprocess.CalledProcessError as e:
-            logger.error(f"Failed to stop worker {container_name}: {e.stderr}")
+            logger.error(f"Failed to stop worker {service_name}: {e.stderr}")
             console.print(f"❌ Failed to stop worker: {e.stderr}", style="red")
             return False
 
         except Exception as e:
-            logger.error(f"Unexpected error stopping worker {container_name}: {e}")
+            logger.error(f"Unexpected error stopping worker {service_name}: {e}")
             console.print(f"❌ Unexpected error: {e}", style="red")
             return False
 
@@ -257,17 +262,18 @@ class WorkerManager:
         Ensure a worker is running, starting it if necessary.
 
         Args:
-            worker_info: Worker information dict from API (contains worker_container, etc.)
+            worker_info: Worker information dict from API (contains worker_service, etc.)
             auto_start: Whether to automatically start the worker if not running
 
         Returns:
             True if worker is running, False otherwise
         """
-        container_name = worker_info["worker_container"]
+        # Get worker_service (docker-compose service name)
+        service_name = worker_info.get("worker_service", f"worker-{worker_info['vertical']}")
         vertical = worker_info["vertical"]
 
         # Check if already running
-        if self.is_worker_running(container_name):
+        if self.is_worker_running(service_name):
             console.print(f"✓ Worker already running: {vertical}")
             return True
 
@@ -279,8 +285,8 @@ class WorkerManager:
             return False
 
         # Start the worker
-        if not self.start_worker(container_name):
+        if not self.start_worker(service_name):
             return False
 
         # Wait for it to be ready
-        return self.wait_for_worker_ready(container_name)
+        return self.wait_for_worker_ready(service_name)

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -1257,7 +1257,7 @@ wheels = [
 
 [[package]]
 name = "fuzzforge-ai"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "../ai" }
 dependencies = [
     { name = "a2a-sdk" },
@@ -1303,7 +1303,7 @@ dev = [
 
 [[package]]
 name = "fuzzforge-cli"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "fuzzforge-ai" },
@@ -1347,7 +1347,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "fuzzforge-sdk"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "../sdk" }
 dependencies = [
     { name = "httpx" },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,6 @@
 #   Development: docker-compose -f docker-compose.temporal.yaml up
 #   Production:  docker-compose -f docker-compose.temporal.yaml -f docker-compose.temporal.prod.yaml up
 
-version: '3.8'
-
 services:
   # ============================================================================
   # Temporal Server - Workflow Orchestration


### PR DESCRIPTION
This PR addresses multiple issues and improvements across the CLI and backend.

## Worker Naming Fixes
- Fix worker container naming mismatch between CLI and docker-compose
- Update `worker_manager.py` to use `docker compose` commands with service names
- Remove `worker_container` field from workflows API, keep only `worker_service`
- Backend now correctly uses service names (`worker-python`, `worker-secrets`, etc.)

## Backend API Fixes
- Fix workflow name extraction from `run_id` in `runs.py` (was showing "unknown")
- Update monitor command suggestions from `monitor stats` to `monitor live`

## Monitor Command Consolidation
- Merge `monitor stats` and `monitor live` into single `monitor live` command
- Add `--once` and `--style` flags for flexibility
- Remove all references to deprecated `monitor stats` command

## Findings CLI Structure Improvements
Closes #18

- Move `show` command from `findings` (plural) to `finding` (singular)
- Keep `export` command in `findings` (plural) as it exports all findings
- Remove broken `analyze` command (imported non-existent function)
- Update all command suggestions to use correct paths
- Fix smart routing logic in `main.py` to handle new command structure
- Add export suggestions after viewing findings with unique timestamps
- Change default export format to SARIF (industry standard)

## Docker Compose
- Remove obsolete `version` field to fix deprecation warning

## Testing
All commands tested and working:
- ✅ `ff finding show <run-id> --rule <rule-id>`
- ✅ `ff findings export <run-id>`
- ✅ `ff finding <run-id>` (direct viewing)
- ✅ `ff monitor live <run-id>`